### PR TITLE
fix: prefer builtin rfc3339 formatter over outdated `iso8601` library

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 {erl_opts, [debug_info]}.
 {deps, [
-  {iso8601, {git, "https://github.com/erlsci/iso8601.git", {tag, "1.3.2"}}},
   {hackney, {git, "https://github.com/emqx/hackney.git", {tag, "1.18.1-1"}}}
 ]}.
 
@@ -8,7 +7,6 @@
   % {config, "config/sys.config"},
     {apps, [
       ots_erl,
-      iso8601,
       hackney
     ]}
 ]}.

--- a/src/ots_erl.app.src
+++ b/src/ots_erl.app.src
@@ -6,7 +6,6 @@
   {applications,
    [kernel,
     stdlib,
-    iso8601,
     hackney
    ]},
   {env,[]},

--- a/src/ots_ts_client.erl
+++ b/src/ots_ts_client.erl
@@ -212,8 +212,9 @@ ts_headers(Client, API, Body) ->
     lists:append(HeadersPart1, [Sign]).
 
 iso8601_now() ->
-    {DatePart1, {H, M, S}} = calendar:universal_time(),
-    iso8601:format({DatePart1, {H, M, S * 1.0}}).
+    %% NOTE: RFC3339 UTC Timestamp is valid ISO8601 Timestamp.
+    Time = erlang:system_time(millisecond),
+    iolist_to_binary(calendar:system_time_to_rfc3339(Time, [{offset, "Z"}, {unit, millisecond}])).
 
 sign(API, AccessSecret, HeadersPart1) ->
     StringToSign = [API, "\nPOST\n\n"],


### PR DESCRIPTION
The latter is not compilable under Erlang/OTP 27 anymore.