### PR TITLE
fix: wire up describe_table request payload and response

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  workflow_call:
+  pull_request:
+    branches:
+      - 'master'
+  push:
+    branches:
+      - 'master'
+      - 'ci/**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  eunit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - otp: 27
+            builder: ghcr.io/emqx/emqx-builder/6.1-8:1.18.3-27.3.4.2-8-ubuntu24.04
+          - otp: 28
+            builder: ghcr.io/emqx/emqx-builder/6.1-8:1.19.1-28.4.1-4-ubuntu24.04
+    container: ${{ matrix.builder }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Work around https://github.com/actions/checkout/issues/766
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Run eunit tests
+        run: rebar3 eunit

--- a/rebar.config
+++ b/rebar.config
@@ -10,3 +10,11 @@
       hackney
     ]}
 ]}.
+
+{profiles, [
+  {test, [
+    {deps, [
+      {meck, "0.9.2"}
+    ]}
+  ]}
+]}.

--- a/src/ots_ts_client.erl
+++ b/src/ots_ts_client.erl
@@ -276,10 +276,14 @@ describe_table_req(Client, SQL) ->
         client = Client,
         sql = SQL,
         api = ?DESCRIBE_TIMESERIES_TABLE,
+        payload = ots_ts_sql:encode_msg(#'DescribeTimeseriesTableRequest'{
+            table_name = maps:get(table_name, SQL)
+        }),
+        expect_resp = 'DescribeTimeseriesTableResponse',
         response_handler = fun describe_table_resp/1
     }.
 
-describe_table_resp(Req) -> {ok, Req}.
+describe_table_resp(Req) -> format(Req).
 
 %% -------------------------------------------------------------------------------------------------
 %% query meta
@@ -646,6 +650,16 @@ format(#'ListTimeseriesTableResponse'{table_metas = TableMetas}) ->
                 status = Status,
                 table_options = #'TimeseriesTableOptions'{
                     time_to_live = TimeToLive}} <- TableMetas]};
+format(#'DescribeTimeseriesTableResponse'{table_meta = #'TimeseriesTableMeta'{
+        table_name = TableName,
+        status = Status,
+        table_options = TableOptions}}) ->
+    TimeToLive =
+        case TableOptions of
+            #'TimeseriesTableOptions'{time_to_live = TTL} -> TTL;
+            _ -> undefined
+        end,
+    {ok, #{table_name => TableName, status => Status, time_to_live => TimeToLive}};
 format(#'ErrorResponse'{code = Code, message = Message}) ->
     {error, #{code => Code, message => Message}}.
 

--- a/test/ots_ts_client_tests.erl
+++ b/test/ots_ts_client_tests.erl
@@ -1,0 +1,130 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+
+-module(ots_ts_client_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("ots_ts_sql.hrl").
+
+-define(OPTS(Pool), [
+    {pool, Pool},
+    {endpoint, <<"https://test.cn-hangzhou.ots.aliyuncs.com">>},
+    {instance, <<"test-instance">>},
+    {access_key, <<"test-access-key">>},
+    {access_secret, <<"test-access-secret">>},
+    {pool_size, 1}
+]).
+
+describe_table_test_() ->
+    {setup,
+        fun() -> start_client(ots_ts_client_test_pool) end,
+        fun stop_client/1,
+        fun(Client) ->
+            [
+                ?_test(describe_table_sends_table_name_payload(Client)),
+                ?_test(describe_table_formats_success_response(Client)),
+                ?_test(describe_table_formats_error_response(Client))
+            ]
+        end}.
+
+list_tables_test_() ->
+    {setup,
+        fun() -> start_client(ots_ts_client_test_pool_list) end,
+        fun stop_client/1,
+        fun(Client) ->
+            [
+                ?_test(list_tables_formats_response(Client))
+            ]
+        end}.
+
+start_client(Pool) ->
+    {ok, _} = application:ensure_all_started(hackney),
+    {ok, _} = application:ensure_all_started(ots_erl),
+    meck:new(hackney, [no_history]),
+    {ok, Client} = ots_ts_client:start(?OPTS(Pool)),
+    Client.
+
+stop_client(Client) ->
+    ots_ts_client:stop(Client),
+    meck:unload(hackney).
+
+describe_table_sends_table_name_payload(Client) ->
+    meck:expect(hackney, request, fun(post, _Url, _Headers, Payload, _Opts) ->
+        put(ots_payload, Payload),
+        {ok, 200, [{<<"x-ots-requestid">>, <<"req-1">>}], describe_table_ok_body()}
+    end),
+    {ok, _} = ots_ts_client:describe_table(Client, #{table_name => <<"probe_table">>}),
+    Payload = get(ots_payload),
+    ?assertNotEqual(<<>>, Payload),
+    ?assertEqual(
+        #'DescribeTimeseriesTableRequest'{table_name = "probe_table"},
+        ots_ts_sql:decode_msg(Payload, 'DescribeTimeseriesTableRequest')
+    ).
+
+describe_table_formats_success_response(Client) ->
+    meck:expect(hackney, request, fun(post, _Url, _Headers, _Payload, _Opts) ->
+        {ok, 200, [{<<"x-ots-requestid">>, <<"req-1">>}], describe_table_ok_body()}
+    end),
+    ?assertMatch(
+        {ok, #{table_name := "probe_table", status := "ACTIVE", time_to_live := 3}},
+        ots_ts_client:describe_table(Client, #{table_name => <<"probe_table">>})
+    ).
+
+describe_table_formats_error_response(Client) ->
+    meck:expect(hackney, request, fun(post, _Url, _Headers, _Payload, _Opts) ->
+        {ok, 400, [{<<"x-ots-requestid">>, <<"req-2">>}], describe_table_error_body()}
+    end),
+    ?assertMatch(
+        {error, #{code := "OTSParameterInvalid", message := "bad table",
+                  http_code := 400, request_id := <<"req-2">>}},
+        ots_ts_client:describe_table(Client, #{table_name => <<"probe_table">>})
+    ).
+
+list_tables_formats_response(Client) ->
+    meck:expect(hackney, request, fun(post, _Url, _Headers, _Payload, _Opts) ->
+        {ok, 200, [{<<"x-ots-requestid">>, <<"req-3">>}], list_tables_ok_body()}
+    end),
+    ?assertMatch(
+        {ok, [#{table_name := "table_a", status := "ACTIVE", time_to_live := 3}]},
+        ots_ts_client:list_tables(Client)
+    ).
+
+describe_table_ok_body() ->
+    ots_ts_sql:encode_msg(#'DescribeTimeseriesTableResponse'{
+        table_meta = #'TimeseriesTableMeta'{
+            table_name = <<"probe_table">>,
+            table_options = #'TimeseriesTableOptions'{time_to_live = 3},
+            status = <<"ACTIVE">>
+        }
+    }).
+
+describe_table_error_body() ->
+    ots_ts_sql:encode_msg(#'ErrorResponse'{
+        code = <<"OTSParameterInvalid">>,
+        message = <<"bad table">>
+    }).
+
+list_tables_ok_body() ->
+    ots_ts_sql:encode_msg(#'ListTimeseriesTableResponse'{
+        table_metas = [
+            #'TimeseriesTableMeta'{
+                table_name = <<"table_a">>,
+                table_options = #'TimeseriesTableOptions'{time_to_live = 3},
+                status = <<"ACTIVE">>
+            }
+        ]
+    }).

--- a/test/ots_ts_client_tests.erl
+++ b/test/ots_ts_client_tests.erl
@@ -14,7 +14,6 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
-
 -module(ots_ts_client_tests).
 
 -include_lib("eunit/include/eunit.hrl").

--- a/test/test.erl
+++ b/test/test.erl
@@ -63,10 +63,10 @@ test() ->
     Opts = [
         {pool, test_demo_pool},
         % {endpoint, <<"https://emqx-demo.cn-hangzhou.ots.aliyuncs.com">>},
-        {endpoint, <<"https://emqx-test.cn-hangzhou.ots.aliyuncs.com">>},
-        {instance, <<"emqx-test">>},
-        {access_key, <<"LTAI5tETEEvA4D7ctpSYvmEg">>},
-        {access_secret, <<"">>},
+        {endpoint, get_env("OTS_TEST_ENDPOINT")},
+        {instance, get_env("OTS_TEST_INSTANCE")},
+        {access_key, get_env("OTS_TEST_ACCESS_KEY_ID")},
+        {access_secret, get_env("OTS_TEST_ACCESS_KEY_SECRET")},
         {pool_size, 1},
         {clean_interval, 5000},
         {cache_timeout, 200}
@@ -110,3 +110,15 @@ read_response(Title, Message) ->
 
 loop_read_response(Title, Message) ->
     io:format("~p : ~0p~n", [Title, Message]).
+
+get_env(Name) ->
+    case os:getenv(Name) of
+        false ->
+            io:format("Missing required env var ~s~n", [Name]),
+            halt(1);
+        "" ->
+            io:format("Env var ~s is set but empty~n", [Name]),
+            halt(1);
+        Value ->
+            list_to_binary(Value)
+    end.


### PR DESCRIPTION
## Summary

- **fix**: `describe_table/2` now encodes the `DescribeTimeseriesTableRequest` payload (table name) and formats the response into a map mirroring `list_tables/1`. Previously it sent an empty request body and returned the raw request record, making the API unusable. This is the driver-side enabler for the EMQX tablestore health-check fix (emqx/emqx#17410).
- **ci**: add GitHub Actions workflow running eunit inside emqx-builder containers on OTP 27/28 (same builder images as emqx/emqx). Transport-mock eunit tests only — no credentials, no external services.
- **test**: make the manual smoke test `test/test.erl` env-driven (`OTS_TEST_*`), drop the hardcoded (and empty-secret) credentials, exit gracefully when env vars are missing.

## Test Plan

- [x] `rebar3 eunit` — 4 tests, 0 failures (local and CI on both OTP 27 and OTP 28)